### PR TITLE
Implement SimpleValueOr<T> structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The `NoBox` library aims to provide an efficient way to operate with primitive v
 
 
 ***
-For example, let's have a look at [this benchmark](https://github.com/Pankraty/NoBox/blob/master/src/NoBox.Benchmarks/Benchmarks/Gen2AllocationsBenchmark.cs). It creates a bunch of primitive objects of 14 different types and put them into list - either `List<System.Object>` (with boxing) or `List<NoBox.SimpleValue>`. On every 1 000 000th iteration the list is cleared, and objects are released.
+For example, let's have a look at [this benchmark](https://github.com/Pankraty/NoBox/blob/master/src/NoBox.Benchmarks/Benchmarks/SimpleValueGen2Allocations.cs). It creates a bunch of primitive objects of 14 different types and put them into a list - either `List<System.Object>` (with boxing) or `List<NoBox.SimpleValue>`. On every 1 000 000th iteration the list is cleared, and objects are released.
 
 Results are fascinating: we've gained more than 3x performance improvement!
 
@@ -19,7 +19,7 @@ Results are fascinating: we've gained more than 3x performance improvement!
 | 'SimpleValue (no boxing)' | 130.7 ms | 2.55 ms |  4.53 ms |  0.28 |
 ```
 
-In [the other benchmark](https://github.com/Pankraty/NoBox/blob/master/src/NoBox.Benchmarks/Benchmarks/Gen0AllocationsBenchmark.cs) we do not preserve the values between iterations, and they are all consumed by GC in generation 0. This time the effect of boxing/unboxing is negligible, and our custom implementation gives way to built-in types, but the difference is about 20-30%, which we find descent.
+In [the other benchmark](https://github.com/Pankraty/NoBox/blob/master/src/NoBox.Benchmarks/Benchmarks/SimpleValueGen0Allocations.cs) we do not preserve the values between iterations, and they are all consumed by GC in generation 0. This time the effect of boxing/unboxing is negligible, and our custom implementation gives way to built-in types, but the difference is about 20-30%, which we find descent.
 
 ```
 |                    Method |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |

--- a/src/NoBox.Benchmarks/Benchmarks/SimpleValueGen0Allocations.cs
+++ b/src/NoBox.Benchmarks/Benchmarks/SimpleValueGen0Allocations.cs
@@ -5,17 +5,18 @@ using System.Collections.Generic;
 
 namespace NoBox.Benchmarks
 {
-    public class Gen2AllocationsBenchmark : IBenchmark
+    public class SimpleValueGen0Allocations : IBenchmark
     {
         public string Description => "In this benchmark we generate many simple values (either boxed to Object " +
-                                     "or presented as SimpleValue) but do not let them be collected in Gen0. " +
-                                     "Here we expect the most apparent difference between the two.";
+                                     "or presented as SimpleValue) that are mostly collected in Gen0. It is natural " +
+                                     "that native types work faster, we just make sure our implementation is not too bad " +
+                                     "in this scenario";
 
         public static int Iterations = 10_000_000;
 
         private readonly BoxedValuesGenerator _boxedValuesGenerator;
         private readonly SimpleValuesGenerator _simpleValuesGenerator;
-        public Gen2AllocationsBenchmark()
+        public SimpleValueGen0Allocations()
         {
             _boxedValuesGenerator = new BoxedValuesGenerator();
             _simpleValuesGenerator = new SimpleValuesGenerator();
@@ -24,17 +25,12 @@ namespace NoBox.Benchmarks
         [Benchmark(Description = "Object (boxing)", Baseline = true)]
         public void Boxing()
         {
-            var l = new List<object>();
-
             var count = 0;
 
             for (int i = 0; i < Iterations; i++)
             {
                 var v = _boxedValuesGenerator.GetNext();
-                l.Add(v);
-                if (l.Count > 1_000_000)
-                    l.Clear();
-
+                
                 if (v is bool b)
                 {
                     count++;
@@ -51,9 +47,6 @@ namespace NoBox.Benchmarks
             for (int i = 0; i < Iterations; i++)
             {
                 var v = _simpleValuesGenerator.GetNext();
-                l.Add(v);
-                if (l.Count > 1_000_000)
-                    l.Clear();
 
                 if (v.ValueType == SimpleValueType.Bool && v)
                 {

--- a/src/NoBox.Benchmarks/Benchmarks/StringAllocationsBenchmark.cs
+++ b/src/NoBox.Benchmarks/Benchmarks/StringAllocationsBenchmark.cs
@@ -1,0 +1,76 @@
+﻿using BenchmarkDotNet.Attributes;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+using NoBox.Benchmarks.Generators;
+
+namespace NoBox.Benchmarks
+{
+    public class SimpleValueOrStringAllocations : IBenchmark
+    {
+        public string Description => "In this benchmark we try to store simple values and strings as either objects or SimpleValueOr<T> structures. " +
+                                     "Here we expect some performance benefit due to fewer garbage collections.";
+
+        public static int Iterations = 10_000_000;
+
+        private readonly BoxedValuesGenerator _boxedValuesGenerator;
+        private readonly SimpleValuesGenerator _simpleValuesGenerator;
+        public SimpleValueOrStringAllocations()
+        {
+            _boxedValuesGenerator = new BoxedValuesGenerator();
+            _simpleValuesGenerator = new SimpleValuesGenerator();
+        }
+
+        [Benchmark(Description = "Object (boxing)", Baseline = true)]
+        public void Boxing()
+        {
+            var l = new List<object>();
+            
+            var count = 0;
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                var v = _boxedValuesGenerator.GetNext();
+                
+                if (v is Guid)
+                    v = v.ToString();
+
+                l.Add(v);
+
+                if (l.Count > 1_000_000)
+                    l.Clear();
+
+                if (v is bool b)
+                {
+                    count++;
+                }
+            }
+        }
+
+        [Benchmark(Description = "SimpleValueOr<String> (no boxing)")]
+        public void NoBoxing()
+        {
+            var l = new List<SimpleValueOr<String>>();
+
+            var count = 0;
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                SimpleValueOr<String> v = _simpleValuesGenerator.GetNext();
+
+                if (v.Value.ValueType == SimpleValueType.Guid)
+                    v = v.ToString();
+
+                l.Add(v);
+                
+                if (l.Count > 1_000_000)
+                    l.Clear();
+
+                if (v.IsValue && v.Value.ValueType == SimpleValueType.Bool && v.Value)
+                {
+                    count++;
+                }
+            }
+        }
+    }
+}

--- a/src/NoBox.Benchmarks/Generators/BoxedValuesGenerator.cs
+++ b/src/NoBox.Benchmarks/Generators/BoxedValuesGenerator.cs
@@ -8,27 +8,29 @@ namespace NoBox.Benchmarks.Generators
 
         public object GetNext()
         {
-            var rem = _counter % 14;
+            var rem = _counter % 16;
             _counter++;
 
-            switch (rem)
+            return rem switch
             {
-                case 0: return true;
-                case 1: return (sbyte)1;
-                case 2: return (byte)2;
-                case 3: return (short)3;
-                case 4: return (ushort)4;
-                case 5: return (int)5;
-                case 6: return (uint)6;
-                case 7: return (long)7;
-                case 8: return (ulong)8;
-                case 9: return (float)9.5;
-                case 10: return (double)10.5;
-                case 11: return (decimal) 11.5m;
-                case 12: return (char)'A';
-                case 13: return new DateTime(2020, 01, 01);
-                default: return TimeSpan.FromHours(1);
-            }
+                0 => (bool) true,
+                1 => (sbyte) 1,
+                2 => (byte) 2,
+                3 => (short) 3,
+                4 => (ushort) 4,
+                5 => (int) 5,
+                6 => (uint) 6,
+                7 => (long) 7,
+                8 => (ulong) 8,
+                9 => (float) 9.5,
+                10 => (double) 10.5,
+                11 => (decimal) 11.5m,
+                12 => (char) 'A',
+                13 => new DateTime(2020, 01, 01),
+                14 => new DateTimeOffset(new DateTime(2020, 01, 01), TimeSpan.FromHours(1)),
+                15 => TimeSpan.FromHours(1),
+                _ => Guid.NewGuid()
+            };
         }
     }
 }

--- a/src/NoBox.Benchmarks/Generators/SimpleValuesGenerator.cs
+++ b/src/NoBox.Benchmarks/Generators/SimpleValuesGenerator.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Pankraty.NoBox;
+﻿using Pankraty.NoBox;
+using System;
 
 namespace NoBox.Benchmarks.Generators
 {
@@ -9,27 +9,29 @@ namespace NoBox.Benchmarks.Generators
 
         public SimpleValue GetNext()
         {
-            var rem = _counter % 14;
+            var rem = _counter % 16;
             _counter++;
 
-            switch (rem)
+            return rem switch
             {
-                case 0: return true;
-                case 1: return (sbyte)1;
-                case 2: return (byte)2;
-                case 3: return (short)3;
-                case 4: return (ushort)4;
-                case 5: return (int)5;
-                case 6: return (uint)6;
-                case 7: return (long)7;
-                case 8: return (ulong)8;
-                case 9: return (float)9.5;
-                case 10: return (double)10.5;
-                case 11: return (decimal)11.5m;
-                case 12: return (char)'A';
-                case 13: return new DateTime(2020, 01, 01);
-                default: return TimeSpan.FromHours(1);
-            }
+                0 => (bool)true,
+                1 => (sbyte)1,
+                2 => (byte)2,
+                3 => (short)3,
+                4 => (ushort)4,
+                5 => (int)5,
+                6 => (uint)6,
+                7 => (long)7,
+                8 => (ulong)8,
+                9 => (float)9.5,
+                10 => (double)10.5,
+                11 => (decimal)11.5m,
+                12 => (char)'A',
+                13 => new DateTime(2020, 01, 01),
+                14 => new DateTimeOffset(new DateTime(2020, 01, 01), TimeSpan.FromHours(1)),
+                15 => TimeSpan.FromHours(1),
+                _ => Guid.NewGuid()
+            };
         }
     }
 }

--- a/src/NoBox.Benchmarks/Program.cs
+++ b/src/NoBox.Benchmarks/Program.cs
@@ -8,8 +8,9 @@ namespace NoBox.Benchmarks
     {
         private static readonly Dictionary<char, Type> _benchmarks = 
             new Dictionary<char, Type> {
-                {'1', typeof(Gen0AllocationsBenchmark) },
-                {'2', typeof(Gen2AllocationsBenchmark) },
+                {'1', typeof(SimpleValueGen0Allocations) },
+                {'2', typeof(SimpleValueGen2Allocations) },
+                {'3', typeof(SimpleValueOrStringAllocations) },
             };
 
         static void Main(string[] args)

--- a/src/NoBox.Tests/NoBox.Tests.csproj
+++ b/src/NoBox.Tests/NoBox.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="AutoFixture" Version="4.11.0"/>
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastBoolTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastBoolTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastBoolTests
+    {
+        [TestCaseSource(nameof(CastBoolInvalidSources))]
+        public void CannotCastBoolToAny<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValue v = true;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+        
+        private static IEnumerable<TestCaseData> CastBoolInvalidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, short         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, int           >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, long          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, float         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, double        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, char          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTime      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTimeOffset>(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, TimeSpan      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, Guid          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal       >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, string        >(v => v));
+            }
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastByteTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastByteTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastByteTests : SimpleValueOrStringCastTestBase
+    {
+        private const byte Default = byte.MaxValue;
+
+        [TestCaseSource(nameof(CastByteValidSources))]
+        public T CanCastByteToNumbers<T>(Func<SimpleValueOrString, T> castMethod, byte initialValue)
+        {
+            SimpleValue v = initialValue;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastByteValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v), (byte)1).Returns((sbyte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v), Default).Returns((sbyte  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v), Default).Returns((byte   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v), Default).Returns((short  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v), Default).Returns((ushort )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v), Default).Returns((int    )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v), Default).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v), Default).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v), Default).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v), Default).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v), Default).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v), Default).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastByteToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValue v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastDateTimeOffsetTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastDateTimeOffsetTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastDateTimeOffsetTests
+    {
+        [TestCaseSource(nameof(CastDateTimeOffsetInvalidSources))]
+        public void CannotCastDateTimeOffsetToAny<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValue v = new DateTimeOffset(new DateTime(2020, 02, 20, 10, 20, 30), TimeSpan.FromHours(2));
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+
+        private static IEnumerable<TestCaseData> CastDateTimeOffsetInvalidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, bool          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, short         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, int           >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, long          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, float         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, double        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, char          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTime      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, TimeSpan      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, Guid          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal       >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, string        >(v => v));
+            }
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastDateTimeTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastDateTimeTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastDateTimeTests
+    {
+        [Test]
+        public void CanCastDateTimeToDateTimeOffset()
+        {
+            SimpleValueOrString v =new DateTime(2020, 02, 20, 10, 20, 30);
+
+            var actualValue = (DateTimeOffset)v;
+            var expectedValue = new DateTimeOffset(new DateTime(2020, 02, 20, 10, 20, 30));
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestCaseSource(nameof(CastDateTimeInvalidSources))]
+        public void CannotCastDateTimeToNonDates<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValue v = new DateTime(2020, 02, 20);
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+
+        private static IEnumerable<TestCaseData> CastDateTimeInvalidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, bool          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, short         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, int           >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, long          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, float         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, double        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, char          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, TimeSpan      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, Guid          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal       >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, string        >(v => v));
+            }
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastDecimalTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastDecimalTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastDecimalTests : SimpleValueOrStringCastTestBase
+    {
+        private const decimal Default = 12.345m;
+
+        [TestCaseSource(nameof(CastDecimalValidSources))]
+        public T CanCastDecimalToNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValue v = Default;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastDecimalValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v)).Returns((sbyte  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v)).Returns((byte   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v)).Returns((short  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v)).Returns((ushort )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v)).Returns((int    )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v)).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v)).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v)).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v)).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v)).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v)).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastDoubleToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastDoubleTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastDoubleTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastDoubleTests : SimpleValueOrStringCastTestBase
+    {
+        private const double Default = 12.345d;
+
+        [TestCaseSource(nameof(CastDoubleValidSources))]
+        public T CanCastDoubleToNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValue v = Default;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastDoubleValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v)).Returns((sbyte  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v)).Returns((byte   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v)).Returns((short  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v)).Returns((ushort )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v)).Returns((int    )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v)).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v)).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v)).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v)).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v)).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v)).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastDoubleToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastFloatTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastFloatTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastFloatTests : SimpleValueOrStringCastTestBase
+    {
+        private const float Default = 12.345f;
+
+        [TestCaseSource(nameof(CastFloatValidSources))]
+        public T CanCastFloatToNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastFloatValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v)).Returns((sbyte  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v)).Returns((byte   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v)).Returns((short  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v)).Returns((ushort )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v)).Returns((int    )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v)).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v)).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v)).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v)).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v)).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v)).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastFloatToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastGuidTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastGuidTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastGuidTests
+    {
+        [TestCaseSource(nameof(CastGuidInvalidSources))]
+        public void CannotCastGuidToAny<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Guid.NewGuid();
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+
+        private static IEnumerable<TestCaseData> CastGuidInvalidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, bool          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, short         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, int           >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, long          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, float         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, double        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, char          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTime      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTimeOffset>(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, TimeSpan      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal       >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, string        >(v => v));
+            }
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastIntTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastIntTests.cs
@@ -1,0 +1,52 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastIntTests : SimpleValueOrStringCastTestBase
+    {
+        private const int Default = int.MaxValue;
+
+        [TestCaseSource(nameof(CastIntValidSources))]
+        public T CanCastIntToNumbers<T>(Func<SimpleValueOrString, T> castMethod, int initialValue)
+        {
+            SimpleValueOrString v = initialValue;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastIntValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),    (int)1).Returns((sbyte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),   Default).Returns((sbyte  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),    (int)1).Returns((byte   )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),   Default).Returns((byte   )255);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),    (int)1).Returns((short  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),   Default).Returns((short  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),    (int)1).Returns((ushort )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),   Default).Returns((ushort )65535);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),   Default).Returns((int    )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v),   Default).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v),   Default).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v),   Default).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v),   Default).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v),   Default).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v),   Default).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastIntToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastLongTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastLongTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastLongTests : SimpleValueOrStringCastTestBase
+    {
+        private const long Default = long.MaxValue;
+
+        [TestCaseSource(nameof(CastLongValidSources))]
+        public T CanCastLongToNumbers<T>(Func<SimpleValueOrString, T> castMethod, long initialValue)
+        {
+            SimpleValueOrString v = initialValue;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastLongValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),   (long)1).Returns((sbyte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),   Default).Returns((sbyte  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),   (long)1).Returns((byte   )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),   Default).Returns((byte   )255);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),   (long)1).Returns((short  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),   Default).Returns((short  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),   (long)1).Returns((ushort )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),   Default).Returns((ushort )65535);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),   (long)1).Returns((int    )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),   Default).Returns((int    )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v),   Default).Returns((uint   )4294967295);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v),   Default).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v),   Default).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v),   Default).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v),   Default).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v),   Default).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastLongToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastSByteTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastSByteTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastSByteTests : SimpleValueOrStringCastTestBase
+    {
+        private const sbyte Default = sbyte.MaxValue;
+
+        [TestCaseSource(nameof(CastSByteValidSources))]
+        public T CanCastSByteToNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValue v = Default;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastSByteValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v)).Returns((sbyte  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v)).Returns((byte   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v)).Returns((short  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v)).Returns((ushort )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v)).Returns((int    )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v)).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v)).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v)).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v)).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v)).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v)).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastSByteToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastShortTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastShortTests.cs
@@ -1,0 +1,50 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastShortTests : SimpleValueOrStringCastTestBase
+    {
+        private const short Default = short.MaxValue;
+
+        [TestCaseSource(nameof(CastShortValidSources))]
+        public T CanCastShortToNumbers<T>(Func<SimpleValueOrString, T> castMethod, short initialValue)
+        {
+            SimpleValueOrString v = initialValue;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastShortValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v), (short)1).Returns((sbyte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),  Default).Returns((sbyte  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v), (short)1).Returns((byte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),  Default).Returns((byte  )255);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),  Default).Returns((short  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),  Default).Returns((ushort )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),  Default).Returns((int    )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v),  Default).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v),  Default).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v),  Default).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v),  Default).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v),  Default).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v),  Default).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastShortToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastStringTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastStringTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastStringTests : SimpleValueOrStringCastTestBase
+    {
+        private const string Default = "Test";
+        
+        [TestCaseSource(nameof(CastStringInvalidSources))]
+        public void CannotCastStringToAny<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+
+        private static IEnumerable<TestCaseData> CastStringInvalidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, bool          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, short         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, int           >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, long          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, float         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, double        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, char          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTime      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTimeOffset>(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, TimeSpan      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, Guid          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal       >(v => v));
+            }
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastTimeSpanTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastTimeSpanTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastTimeSpanTests
+    {
+        [TestCaseSource(nameof(CastTimeSpanInvalidSources))]
+        public void CannotCastTimeSpanToAny<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = TimeSpan.FromHours(5);
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+
+        private static IEnumerable<TestCaseData> CastTimeSpanInvalidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, bool          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, short         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, int           >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, long          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, float         >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, double        >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, char          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTime      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTimeOffset>(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, Guid          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal       >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, string        >(v => v));
+            }
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastUIntTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastUIntTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastUIntTests : SimpleValueOrStringCastTestBase
+    {
+        private const uint Default = uint.MaxValue;
+
+        [TestCaseSource(nameof(CastUIntValidSources))]
+        public T CanCastUIntToNumbers<T>(Func<SimpleValueOrString, T> castMethod, uint initialValue)
+        {
+            SimpleValueOrString v = initialValue;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastUIntValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),   (uint)1).Returns((sbyte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),   Default).Returns((sbyte  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),   (uint)1).Returns((byte   )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),   Default).Returns((byte   )255);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),   (uint)1).Returns((short  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),   Default).Returns((short  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),   (uint)1).Returns((ushort )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),   Default).Returns((ushort )65535);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),   (uint)1).Returns((int    )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),   Default).Returns((int    )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v),   Default).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v),   Default).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v),   Default).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v),   Default).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v),   Default).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v),   Default).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastUIntToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastULongTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastULongTests.cs
@@ -1,0 +1,54 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastULongTests : SimpleValueOrStringCastTestBase
+    {
+        private const ulong Default = ulong.MaxValue;
+
+        [TestCaseSource(nameof(CastULongValidSources))]
+        public T CanCastULongToNumbers<T>(Func<SimpleValueOrString, T> castMethod, ulong initialValue)
+        {
+            SimpleValueOrString v = initialValue;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastULongValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),  (ulong)1).Returns((sbyte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),   Default).Returns((sbyte  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),  (ulong)1).Returns((byte   )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),   Default).Returns((byte   )255);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),  (ulong)1).Returns((short  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),   Default).Returns((short  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),  (ulong)1).Returns((ushort )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),   Default).Returns((ushort )65535);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),  (ulong)1).Returns((int    )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),   Default).Returns((int    )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v),   Default).Returns((uint   )4294967295);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v),  (ulong)1).Returns((long   )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v),   Default).Returns((long   )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v),   Default).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v),   Default).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v),   Default).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v),   Default).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastULongToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastUShortTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/CastUShortTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class CastUShortTests : SimpleValueOrStringCastTestBase
+    {
+        private const ushort Default = ushort.MaxValue;
+
+        [TestCaseSource(nameof(CastUShortValidSources))]
+        public T CanCastUShortToNumbers<T>(Func<SimpleValueOrString, T> castMethod, ushort initialValue)
+        {
+            SimpleValueOrString v = initialValue;
+
+            return castMethod(v);
+        }
+
+        private static IEnumerable<TestCaseData> CastUShortValidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v), (ushort)1).Returns((sbyte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, sbyte   >(v => v),   Default).Returns((sbyte  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v), (ushort)1).Returns((byte  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, byte    >(v => v),   Default).Returns((byte  )255);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v), (ushort)1).Returns((short  )1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, short   >(v => v),   Default).Returns((short  )-1);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ushort  >(v => v),   Default).Returns((ushort )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, int     >(v => v),   Default).Returns((int    )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, uint    >(v => v),   Default).Returns((uint   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, long    >(v => v),   Default).Returns((long   )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, ulong   >(v => v),   Default).Returns((ulong  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, float   >(v => v),   Default).Returns((float  )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, double  >(v => v),   Default).Returns((double )Default);
+                yield return new TestCaseData(new Func<SimpleValueOrString, decimal >(v => v),   Default).Returns((decimal)Default);
+            }
+        }
+
+        [TestCaseSource(nameof(CastNumberInvalidSources))]
+        public void CannotCastUShortToNonNumbers<T>(Func<SimpleValueOrString, T> castMethod)
+        {
+            SimpleValueOrString v = Default;
+
+            Assert.Throws<InvalidCastException>(() => castMethod(v));
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/SimpleValueCastBackTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/SimpleValueCastBackTests.cs
@@ -1,0 +1,131 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class SimpleValueOrStringCastBackTests : TheoryTestBase
+    {
+        [Theory]
+        public void CanCastBackToBool(bool value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (bool) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToByte(byte value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (byte) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToChar(char value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (char) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToDateTime(DateTime value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (DateTime) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToDecimal(decimal value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (decimal) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToDouble(double value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (double) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToFloat(float value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (float) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToInt(int value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (int) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToLong(long value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (long) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToSByte(sbyte value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (sbyte) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToShort(short value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (short) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToTimeSpan(TimeSpan value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (TimeSpan) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToUInt(uint value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (uint) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToULong(ulong value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (ulong) s;
+            Assert.AreEqual(value, actualValue);
+        }
+
+        [Theory]
+        public void CanCastBackToUShort(ushort value)
+        {
+            SimpleValueOrString s = value;
+            var actualValue = (ushort) s;
+            Assert.AreEqual(value, actualValue);
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/CastTests/SimpleValueOrStringCastTestBase.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/CastTests/SimpleValueOrStringCastTestBase.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests.CastTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public abstract class SimpleValueOrStringCastTestBase
+    {
+        public static IEnumerable<TestCaseData> CastNumberInvalidSources
+        {
+            get
+            {
+                yield return new TestCaseData(new Func<SimpleValueOrString, bool          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, char          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTime      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, DateTimeOffset>(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, TimeSpan      >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, Guid          >(v => v));
+                yield return new TestCaseData(new Func<SimpleValueOrString, string        >(v => v));
+            }
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/SimpleValueOrTCreateTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/SimpleValueOrTCreateTests.cs
@@ -1,0 +1,163 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+
+namespace NoBox.Tests.SimpleValueOrTTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class SimpleValueOrTCreateTests : TheoryTestBase
+    {
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromBool(bool value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Bool, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromByte(byte value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Byte, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromChar(char value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Char, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromDateTime(DateTime value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.DateTime, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromDateTimeOffset(DateTimeOffset value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.DateTimeOffset, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromDecimal(decimal value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Decimal, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromDouble(double value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Double, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromFloat(float value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Float, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromGuid(Guid value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Guid, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromInt(int value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Int, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromLong(long value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Long, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromSByte(sbyte value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.SByte, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromShort(short value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.Short, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromTimeSpan(TimeSpan value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.TimeSpan, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromUInt(uint value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.UInt, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromULong(ulong value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.ULong, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromUShort(ushort value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsTrue(s.IsValue);
+            Assert.AreEqual(SimpleValueType.UShort, s.Value.ValueType);
+        }
+
+        [Theory]
+        public void CanCreateSimpleValueOrString_FromString(string value)
+        {
+            SimpleValueOrString s = value;
+            Assert.IsFalse(s.IsValue);
+            Assert.AreSame(value, s.Reference);
+        }
+
+        [Test]
+        public void CanCreateSimpleValueOrString_FromNull()
+        {
+            SimpleValueOrString s = null;
+            Assert.IsFalse(s.IsValue);
+            Assert.IsNull(s.Reference);
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueOrTTests/SimpleValueOrTToStringTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/SimpleValueOrTToStringTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
+
+namespace NoBox.Tests.SimpleValueOrTTests
+{
+    using SimpleValueOrString = SimpleValueOr<String>;
+
+    public class SimpleValueOrTToStringTests
+    {
+        [TestCaseSource(nameof(ToStringSources))]
+        public string SimpleValueOrString_ToString(SimpleValueOrString value)
+        {
+            return value.ToString();
+        }
+
+        private static IEnumerable<TestCaseData> ToStringSources
+        {
+            get
+            {
+                yield return new TestCaseData((SimpleValueOrString)null).Returns(null);
+                yield return new TestCaseData((SimpleValueOrString)"Test").Returns("Test");
+                yield return new TestCaseData((SimpleValueOrString)123).Returns("123");
+            }
+        }
+    }
+}

--- a/src/NoBox.Tests/SimpleValueTests/SimpleValueIsNumberTests.cs
+++ b/src/NoBox.Tests/SimpleValueTests/SimpleValueIsNumberTests.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 using Pankraty.NoBox;
+using System;
+using System.Collections.Generic;
 
 namespace NoBox.Tests.SimpleValueTests
 {

--- a/src/NoBox.Tests/SimpleValueTests/SimpleValueToStringTests.cs
+++ b/src/NoBox.Tests/SimpleValueTests/SimpleValueToStringTests.cs
@@ -1,9 +1,9 @@
+using NUnit.Framework;
+using Pankraty.NoBox;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
-using NUnit.Framework;
-using Pankraty.NoBox;
 
 namespace NoBox.Tests.SimpleValueTests
 {

--- a/src/NoBox.Tests/TheoryTestBase.cs
+++ b/src/NoBox.Tests/TheoryTestBase.cs
@@ -1,25 +1,25 @@
-using System;
 using NUnit.Framework;
+using System;
 
 namespace NoBox.Tests
 {
     public abstract class TheoryTestBase
     {
-        [DatapointSource] public byte[] Bytes         = new[] { byte.MinValue, (byte)1, byte.MaxValue};
-        [DatapointSource] public char[] Chars         = new[] { char.MinValue, '$'};
-        [DatapointSource] public DateTime[] DateTimes = new[] { DateTime.MinValue, new DateTime(2020, 02, 20), DateTime.MaxValue};
+        [DatapointSource] public byte[] Bytes                     = new[] { byte.MinValue, (byte)1, byte.MaxValue};
+        [DatapointSource] public char[] Chars                     = new[] { char.MinValue, '$'};
+        [DatapointSource] public DateTime[] DateTimes             = new[] { DateTime.MinValue, new DateTime(2020, 02, 20), DateTime.MaxValue};
         [DatapointSource] public DateTimeOffset[] DateTimeOffsets = new[] { DateTimeOffset.MinValue, new DateTimeOffset(new DateTime(2020, 02, 20), TimeSpan.FromHours(2)), DateTimeOffset.MaxValue};
-        [DatapointSource] public decimal[] Decimals   = new[] { decimal.MinValue, 0m, 0.123m, decimal.MaxValue};
-        [DatapointSource] public double[] Doubles     = new[] { double.MinValue, 0, 0.123, double.MaxValue};
-        [DatapointSource] public Guid[] Guids         = new[] { Guid.Empty, Guid.Parse("C581C36F-1B84-4FC7-A2C8-F04601DFAC87") };
-        [DatapointSource] public float[] Floats       = new[] { float.MinValue, (float)0, (float)0.123, float.MaxValue};
-        [DatapointSource] public int[] Ints           = new[] { int.MinValue, 0, 10, int.MaxValue};
-        [DatapointSource] public long[] Longs         = new[] { long.MinValue, (long)0, (long)10, long.MaxValue};
-        [DatapointSource] public sbyte[] SBytes       = new[] { sbyte.MinValue, (sbyte)0, (sbyte)10, sbyte.MaxValue};
-        [DatapointSource] public short[] Shorts       = new[] { short.MinValue, (short)0, (short)10, short.MaxValue};
-        [DatapointSource] public TimeSpan[] TimeSpans = new[] { TimeSpan.MinValue, TimeSpan.Zero, TimeSpan.FromDays(1), TimeSpan.MaxValue };
-        [DatapointSource] public uint[] UInts         = new[] { uint.MinValue, (uint)0, (uint)10, uint.MaxValue };
-        [DatapointSource] public ulong[] ULongs       = new[] { ulong.MinValue, (ulong)0, (ulong)10, ulong.MaxValue };
-        [DatapointSource] public ushort[] UShorts     = new[] { ushort.MinValue, (ushort)0, (ushort)10, ushort.MaxValue };
+        [DatapointSource] public decimal[] Decimals               = new[] { decimal.MinValue, 0m, 0.123m, decimal.MaxValue};
+        [DatapointSource] public double[] Doubles                 = new[] { double.MinValue, 0, 0.123, double.MaxValue};
+        [DatapointSource] public Guid[] Guids                     = new[] { Guid.Empty, Guid.Parse("C581C36F-1B84-4FC7-A2C8-F04601DFAC87") };
+        [DatapointSource] public float[] Floats                   = new[] { float.MinValue, (float)0, (float)0.123, float.MaxValue};
+        [DatapointSource] public int[] Ints                       = new[] { int.MinValue, 0, 10, int.MaxValue};
+        [DatapointSource] public long[] Longs                     = new[] { long.MinValue, (long)0, (long)10, long.MaxValue};
+        [DatapointSource] public sbyte[] SBytes                   = new[] { sbyte.MinValue, (sbyte)0, (sbyte)10, sbyte.MaxValue};
+        [DatapointSource] public short[] Shorts                   = new[] { short.MinValue, (short)0, (short)10, short.MaxValue};
+        [DatapointSource] public TimeSpan[] TimeSpans             = new[] { TimeSpan.MinValue, TimeSpan.Zero, TimeSpan.FromDays(1), TimeSpan.MaxValue };
+        [DatapointSource] public uint[] UInts                     = new[] { uint.MinValue, (uint)0, (uint)10, uint.MaxValue };
+        [DatapointSource] public ulong[] ULongs                   = new[] { ulong.MinValue, (ulong)0, (ulong)10, ulong.MaxValue };
+        [DatapointSource] public ushort[] UShorts                 = new[] { ushort.MinValue, (ushort)0, (ushort)10, ushort.MaxValue };
     }
 }

--- a/src/NoBox.Tests/TheoryTestBase.cs
+++ b/src/NoBox.Tests/TheoryTestBase.cs
@@ -21,5 +21,6 @@ namespace NoBox.Tests
         [DatapointSource] public uint[] UInts                     = new[] { uint.MinValue, (uint)0, (uint)10, uint.MaxValue };
         [DatapointSource] public ulong[] ULongs                   = new[] { ulong.MinValue, (ulong)0, (ulong)10, ulong.MaxValue };
         [DatapointSource] public ushort[] UShorts                 = new[] { ushort.MinValue, (ushort)0, (ushort)10, ushort.MaxValue };
+        [DatapointSource] public string[] Strings                 = new[] { "", "Test" };
     }
 }

--- a/src/NoBox/SimpleValue.cs
+++ b/src/NoBox/SimpleValue.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace Pankraty.NoBox
 {
     [StructLayout(LayoutKind.Explicit)]
-    public struct SimpleValue
+    public readonly struct SimpleValue
     {
         private const int DataOffset = 4;
 

--- a/src/NoBox/SimpleValue.cs
+++ b/src/NoBox/SimpleValue.cs
@@ -304,7 +304,7 @@ namespace Pankraty.NoBox
             throw new InvalidCastException();
         }
 
-        public static implicit operator Guid(SimpleValue value)
+        public static implicit operator Guid          (SimpleValue value)
         {
             if (value.ValueType == SimpleValueType.Guid)
                 return value._guidValue;
@@ -358,7 +358,6 @@ namespace Pankraty.NoBox
         /// <summary>
         /// Converts the value of this instance to its equivalent string representation using the formatting conventions of the current culture.
         /// </summary>
-        /// <exception cref="T:System.FormatException"><paramref name="format">format</paramref> is invalid.</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException">The date and time is outside the range of dates supported by the calendar used by <paramref name="provider">provider</paramref>.</exception>
         public override string ToString()
         {

--- a/src/NoBox/SimpleValueOrT.cs
+++ b/src/NoBox/SimpleValueOrT.cs
@@ -1,0 +1,250 @@
+﻿using System;
+
+namespace Pankraty.NoBox
+{
+    /// <summary>
+    /// A wrapper type that allows storing a simple value or an instance of a reference type
+    /// in the same field without boxing simple values.
+    /// </summary>
+    public readonly struct SimpleValueOr<T> where T : class
+    {
+        #region Public Properties
+
+        public bool IsValue => _isValue;
+
+        public SimpleValue Value
+        {
+            get
+            {
+                if (_isValue)
+                    return _value;
+
+                throw new InvalidOperationException($"This instance is not a simple value. Use {nameof(Reference)} property");
+            }
+        }
+
+        public T Reference
+        {
+            get
+            {
+                if (!_isValue)
+                    return _reference;
+
+                throw new InvalidOperationException($"This instance is not a reference. Use {nameof(Value)} property");
+            }
+        }
+
+        #endregion Public Properties
+
+        #region Private Fields
+
+        private readonly bool _isValue;
+        private readonly SimpleValue _value;
+        private readonly T _reference;
+
+        #endregion Private Fields
+
+        #region Constructors
+
+        public SimpleValueOr(SimpleValue value) : this()
+        {
+            _isValue = true;
+            _value = value;
+        }
+
+        public SimpleValueOr(T reference) : this()
+        {
+            _reference = reference;
+        }
+
+        #endregion Constructors
+
+        #region Implicit Casts
+
+        public static implicit operator SimpleValue(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator bool(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator sbyte(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator byte(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator short(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator ushort(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator int(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator uint(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator long(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator ulong(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator float(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator double(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator char(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator DateTime(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator DateTimeOffset(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator TimeSpan(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator Guid(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator decimal(SimpleValueOr<T> value)
+        {
+            if (value._isValue)
+                return value._value;
+
+            throw new InvalidCastException();
+        }
+
+        public static implicit operator T(SimpleValueOr<T> value)
+        {
+            if (!value._isValue)
+                return value._reference;
+
+            throw new InvalidCastException();
+        }
+
+
+        public static implicit operator SimpleValueOr<T> (SimpleValue    value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (bool           value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (sbyte          value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (byte           value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (short          value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (ushort         value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (int            value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (uint           value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (long           value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (ulong          value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (float          value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (double         value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (char           value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (DateTime       value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (DateTimeOffset value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (TimeSpan       value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (Guid           value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (decimal        value) { return new SimpleValueOr<T>(value); }
+        public static implicit operator SimpleValueOr<T> (T              value) { return new SimpleValueOr<T>(value); }
+
+        #endregion Implicit Casts
+
+        #region ToString
+
+        public override string ToString()
+        {
+            return _isValue
+                ? _value.ToString()
+                : _reference?.ToString();
+        }
+
+        #endregion ToString
+    }
+}


### PR DESCRIPTION
Implement `SimpleValueOr<T>` structure to support storing values without boxing and arbitrary references in the same field