### PR TITLE
Implement Create<T> method

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: 0.1.0.{build}
 
 os: Visual Studio 2019
 image: Visual Studio 2019
+skip_branch_with_pr: true
 
 environment:
   AppVeyor: APPVEYOR

--- a/src/NoBox.Benchmarks/Benchmarks/ShortValueGen2Allocations.cs
+++ b/src/NoBox.Benchmarks/Benchmarks/ShortValueGen2Allocations.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace Pankraty.NoBox.Benchmarks.Benchmarks
 {
+    [MemoryDiagnoser]
     public class ShortValueGen2Allocations : IBenchmark
     {
         public string Description => "In this benchmark we generate many simple values (either boxed to Object " +

--- a/src/NoBox.Benchmarks/Benchmarks/SimpleValueGen0Allocations.cs
+++ b/src/NoBox.Benchmarks/Benchmarks/SimpleValueGen0Allocations.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace Pankraty.NoBox.Benchmarks.Benchmarks
 {
+    [MemoryDiagnoser]
     public class SimpleValueGen0Allocations : IBenchmark
     {
         public string Description => "In this benchmark we generate many simple values (either boxed to Object " +

--- a/src/NoBox.Benchmarks/Benchmarks/SimpleValueGen2Allocations.cs
+++ b/src/NoBox.Benchmarks/Benchmarks/SimpleValueGen2Allocations.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace Pankraty.NoBox.Benchmarks.Benchmarks
 {
+    [MemoryDiagnoser]
     public class SimpleValueGen2Allocations : IBenchmark
     {
         public string Description => "In this benchmark we generate many simple values (either boxed to Object " +

--- a/src/NoBox.Benchmarks/Benchmarks/StringAllocationsBenchmark.cs
+++ b/src/NoBox.Benchmarks/Benchmarks/StringAllocationsBenchmark.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 
 namespace Pankraty.NoBox.Benchmarks.Benchmarks
 {
+    [MemoryDiagnoser]
     public class SimpleValueOrStringAllocations : IBenchmark
     {
         public string Description => "In this benchmark we try to store simple values and strings as either objects or SimpleValueOr<T> structures. " +

--- a/src/NoBox.Benchmarks/NoBox.Benchmarks.csproj
+++ b/src/NoBox.Benchmarks/NoBox.Benchmarks.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net46</TargetFrameworks>
+    <LangVersion>8</LangVersion>
     <RootNamespace>Pankraty.NoBox.Benchmarks</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoBox.Tests/Common/CastSamples.Generated.cs
+++ b/src/NoBox.Tests/Common/CastSamples.Generated.cs
@@ -724,6 +724,44 @@ namespace Pankraty.NoBox.Tests.Common
             new CastDefinition<SimpleValue, decimal>(SimpleValue_decimal, v => v.CastTo<decimal>(), (decimal)Default_decimal),
 
             #endregion Explicit cast from SimpleValue to every type
+            
+            #region Create SimpleValue from a generic argument
+
+            new CastDefinition<bool, SimpleValue>(Default_bool, v => SimpleValue.Create(v), (SimpleValue)Default_bool),
+
+            new CastDefinition<sbyte, SimpleValue>(Default_sbyte, v => SimpleValue.Create(v), (SimpleValue)Default_sbyte),
+
+            new CastDefinition<byte, SimpleValue>(Default_byte, v => SimpleValue.Create(v), (SimpleValue)Default_byte),
+
+            new CastDefinition<short, SimpleValue>(Default_short, v => SimpleValue.Create(v), (SimpleValue)Default_short),
+
+            new CastDefinition<ushort, SimpleValue>(Default_ushort, v => SimpleValue.Create(v), (SimpleValue)Default_ushort),
+
+            new CastDefinition<int, SimpleValue>(Default_int, v => SimpleValue.Create(v), (SimpleValue)Default_int),
+
+            new CastDefinition<uint, SimpleValue>(Default_uint, v => SimpleValue.Create(v), (SimpleValue)Default_uint),
+
+            new CastDefinition<long, SimpleValue>(Default_long, v => SimpleValue.Create(v), (SimpleValue)Default_long),
+
+            new CastDefinition<ulong, SimpleValue>(Default_ulong, v => SimpleValue.Create(v), (SimpleValue)Default_ulong),
+
+            new CastDefinition<float, SimpleValue>(Default_float, v => SimpleValue.Create(v), (SimpleValue)Default_float),
+
+            new CastDefinition<double, SimpleValue>(Default_double, v => SimpleValue.Create(v), (SimpleValue)Default_double),
+
+            new CastDefinition<char, SimpleValue>(Default_char, v => SimpleValue.Create(v), (SimpleValue)Default_char),
+
+            new CastDefinition<DateTime, SimpleValue>(Default_DateTime, v => SimpleValue.Create(v), (SimpleValue)Default_DateTime),
+
+            new CastDefinition<DateTimeOffset, SimpleValue>(Default_DateTimeOffset, v => SimpleValue.Create(v), (SimpleValue)Default_DateTimeOffset),
+
+            new CastDefinition<TimeSpan, SimpleValue>(Default_TimeSpan, v => SimpleValue.Create(v), (SimpleValue)Default_TimeSpan),
+
+            new CastDefinition<Guid, SimpleValue>(Default_Guid, v => SimpleValue.Create(v), (SimpleValue)Default_Guid),
+
+            new CastDefinition<decimal, SimpleValue>(Default_decimal, v => SimpleValue.Create(v), (SimpleValue)Default_decimal),
+
+            #endregion Create SimpleValue from a generic argument
 
             #region Implicit cast from SimpleValueOr<String> to every type
         
@@ -1458,6 +1496,48 @@ namespace Pankraty.NoBox.Tests.Common
             new CastDefinition<SimpleValueOr<String>, SimpleValue>(SimpleValueOrString_SimpleValue, v => v.CastTo<SimpleValue>(), (SimpleValue)Default_SimpleValue),
 
             #endregion Explicit cast from SimpleValueOr<String> to every type
+            
+            #region Create SimpleValueOr<String> from a generic argument
+
+            new CastDefinition<bool, SimpleValueOr<String>>(Default_bool, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_bool),
+
+            new CastDefinition<sbyte, SimpleValueOr<String>>(Default_sbyte, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_sbyte),
+
+            new CastDefinition<byte, SimpleValueOr<String>>(Default_byte, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_byte),
+
+            new CastDefinition<short, SimpleValueOr<String>>(Default_short, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_short),
+
+            new CastDefinition<ushort, SimpleValueOr<String>>(Default_ushort, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_ushort),
+
+            new CastDefinition<int, SimpleValueOr<String>>(Default_int, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_int),
+
+            new CastDefinition<uint, SimpleValueOr<String>>(Default_uint, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_uint),
+
+            new CastDefinition<long, SimpleValueOr<String>>(Default_long, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_long),
+
+            new CastDefinition<ulong, SimpleValueOr<String>>(Default_ulong, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_ulong),
+
+            new CastDefinition<float, SimpleValueOr<String>>(Default_float, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_float),
+
+            new CastDefinition<double, SimpleValueOr<String>>(Default_double, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_double),
+
+            new CastDefinition<char, SimpleValueOr<String>>(Default_char, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_char),
+
+            new CastDefinition<DateTime, SimpleValueOr<String>>(Default_DateTime, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_DateTime),
+
+            new CastDefinition<DateTimeOffset, SimpleValueOr<String>>(Default_DateTimeOffset, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_DateTimeOffset),
+
+            new CastDefinition<TimeSpan, SimpleValueOr<String>>(Default_TimeSpan, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_TimeSpan),
+
+            new CastDefinition<Guid, SimpleValueOr<String>>(Default_Guid, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_Guid),
+
+            new CastDefinition<decimal, SimpleValueOr<String>>(Default_decimal, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_decimal),
+
+            new CastDefinition<string, SimpleValueOr<String>>(Default_string, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_string),
+
+            new CastDefinition<SimpleValue, SimpleValueOr<String>>(Default_SimpleValue, v => SimpleValueOr<String>.Create(v), (SimpleValueOr<String>)Default_SimpleValue),
+
+            #endregion Create SimpleValueOr<String> from a generic argument
 
             #region Implicit cast from ShortValue to every type
         
@@ -1886,6 +1966,38 @@ namespace Pankraty.NoBox.Tests.Common
             new CastDefinition<ShortValue, TimeSpan>(ShortValue_TimeSpan, v => v.CastTo<TimeSpan>(), (TimeSpan)Default_TimeSpan),
 
             #endregion Explicit cast from ShortValue to every type
+            
+            #region Create ShortValue from a generic argument
+
+            new CastDefinition<bool, ShortValue>(Default_bool, v => ShortValue.Create(v), (ShortValue)Default_bool),
+
+            new CastDefinition<sbyte, ShortValue>(Default_sbyte, v => ShortValue.Create(v), (ShortValue)Default_sbyte),
+
+            new CastDefinition<byte, ShortValue>(Default_byte, v => ShortValue.Create(v), (ShortValue)Default_byte),
+
+            new CastDefinition<short, ShortValue>(Default_short, v => ShortValue.Create(v), (ShortValue)Default_short),
+
+            new CastDefinition<ushort, ShortValue>(Default_ushort, v => ShortValue.Create(v), (ShortValue)Default_ushort),
+
+            new CastDefinition<int, ShortValue>(Default_int, v => ShortValue.Create(v), (ShortValue)Default_int),
+
+            new CastDefinition<uint, ShortValue>(Default_uint, v => ShortValue.Create(v), (ShortValue)Default_uint),
+
+            new CastDefinition<long, ShortValue>(Default_long, v => ShortValue.Create(v), (ShortValue)Default_long),
+
+            new CastDefinition<ulong, ShortValue>(Default_ulong, v => ShortValue.Create(v), (ShortValue)Default_ulong),
+
+            new CastDefinition<float, ShortValue>(Default_float, v => ShortValue.Create(v), (ShortValue)Default_float),
+
+            new CastDefinition<double, ShortValue>(Default_double, v => ShortValue.Create(v), (ShortValue)Default_double),
+
+            new CastDefinition<char, ShortValue>(Default_char, v => ShortValue.Create(v), (ShortValue)Default_char),
+
+            new CastDefinition<DateTime, ShortValue>(Default_DateTime, v => ShortValue.Create(v), (ShortValue)Default_DateTime),
+
+            new CastDefinition<TimeSpan, ShortValue>(Default_TimeSpan, v => ShortValue.Create(v), (ShortValue)Default_TimeSpan),
+
+            #endregion Create ShortValue from a generic argument
 
             #region Implicit cast from ShortValueOr<String> to every type
         
@@ -2410,6 +2522,42 @@ namespace Pankraty.NoBox.Tests.Common
             new CastDefinition<ShortValueOr<String>, ShortValue>(ShortValueOrString_ShortValue, v => v.CastTo<ShortValue>(), (ShortValue)Default_ShortValue),
 
             #endregion Explicit cast from ShortValueOr<String> to every type
+            
+            #region Create ShortValueOr<String> from a generic argument
+
+            new CastDefinition<bool, ShortValueOr<String>>(Default_bool, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_bool),
+
+            new CastDefinition<sbyte, ShortValueOr<String>>(Default_sbyte, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_sbyte),
+
+            new CastDefinition<byte, ShortValueOr<String>>(Default_byte, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_byte),
+
+            new CastDefinition<short, ShortValueOr<String>>(Default_short, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_short),
+
+            new CastDefinition<ushort, ShortValueOr<String>>(Default_ushort, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_ushort),
+
+            new CastDefinition<int, ShortValueOr<String>>(Default_int, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_int),
+
+            new CastDefinition<uint, ShortValueOr<String>>(Default_uint, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_uint),
+
+            new CastDefinition<long, ShortValueOr<String>>(Default_long, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_long),
+
+            new CastDefinition<ulong, ShortValueOr<String>>(Default_ulong, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_ulong),
+
+            new CastDefinition<float, ShortValueOr<String>>(Default_float, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_float),
+
+            new CastDefinition<double, ShortValueOr<String>>(Default_double, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_double),
+
+            new CastDefinition<char, ShortValueOr<String>>(Default_char, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_char),
+
+            new CastDefinition<DateTime, ShortValueOr<String>>(Default_DateTime, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_DateTime),
+
+            new CastDefinition<TimeSpan, ShortValueOr<String>>(Default_TimeSpan, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_TimeSpan),
+
+            new CastDefinition<string, ShortValueOr<String>>(Default_string, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_string),
+
+            new CastDefinition<ShortValue, ShortValueOr<String>>(Default_ShortValue, v => ShortValueOr<String>.Create(v), (ShortValueOr<String>)Default_ShortValue),
+
+            #endregion Create ShortValueOr<String> from a generic argument
 
         };
     }

--- a/src/NoBox.Tests/Common/CastSamples.Generated.tt
+++ b/src/NoBox.Tests/Common/CastSamples.Generated.tt
@@ -258,6 +258,21 @@ namespace Pankraty.NoBox.Tests.Common
     }
 #>
             #endregion Explicit cast from <#= typeKey#> to every type
+            
+            #region Create <#= typeKey#> from a generic argument
+
+<# 
+    for (var i = 0; i < templateDefinition.ClrTypes.Length; i++)
+    {
+        var fromType = templateDefinition.ClrTypes[i];
+        var expectedResult = $"({typeKey})Default_{fromType}";
+#>
+            new CastDefinition<<#= fromType#>, <#= typeKey#>>(Default_<#= fromType#>, v => <#= typeKey#>.Create(v), <#= expectedResult#>),
+
+<#
+    }
+#>
+            #endregion Create <#= typeKey#> from a generic argument
 
 <#
     }

--- a/src/NoBox.Tests/Common/CastSamples.cs
+++ b/src/NoBox.Tests/Common/CastSamples.cs
@@ -42,7 +42,7 @@ namespace Pankraty.NoBox.Tests.Common
         public static IEnumerable<TestCaseData> GetValidCasts(Type fromType)
         {
             return AllCasts
-                .Where(cst => cst.IsValid && cst.From == fromType)
+                .Where(cst => cst.IsValid && cst.From == fromType || cst.To == fromType)
                 .Select(cst => cst.ToTestCase());
         }
 
@@ -52,7 +52,7 @@ namespace Pankraty.NoBox.Tests.Common
         public static IEnumerable<TestCaseData> GetInvalidCasts(Type fromType)
         {
             return AllCasts
-                .Where(cst => !cst.IsValid && cst.From == fromType)
+                .Where(cst => !cst.IsValid && cst.From == fromType || cst.To == fromType)
                 .Select(cst => cst.ToTestCase());
         }
     }

--- a/src/NoBox.Tests/ShortValueOrTTests/ShortValueOrTCreateTests.cs
+++ b/src/NoBox.Tests/ShortValueOrTTests/ShortValueOrTCreateTests.cs
@@ -148,5 +148,23 @@ namespace Pankraty.NoBox.Tests.ShortValueOrTTests
             ShortValueOrString s = value;
             Assert.Throws<InvalidOperationException>(() => { _ = s.Value; });
         }
+
+        [Test]
+        public void CanCreateShortValueFromGenericT()
+        {
+            var inputValue = 1;
+            var valueResult = Convert(inputValue);
+            Assert.IsTrue(valueResult.IsValue);
+
+            var inputReference = "Test";
+            var referenceResult = Convert(inputReference);
+            Assert.IsFalse(referenceResult.IsValue);
+            Assert.AreEqual("Test", referenceResult.Reference);
+
+            ShortValueOr<object> Convert<T>(T value)
+            {
+                return ShortValueOr<object>.Create(value);
+            }
+        }
     }
 }

--- a/src/NoBox.Tests/ShortValueTests/ShortValueCreateTests.cs
+++ b/src/NoBox.Tests/ShortValueTests/ShortValueCreateTests.cs
@@ -113,5 +113,11 @@ namespace Pankraty.NoBox.Tests.ShortValueTests
             ShortValue s = value;
             Assert.AreEqual(SimpleValueType.UShort, s.ValueType);
         }
+
+        [Theory]
+        public void CannotCreateShortValue_FromGuid(Guid value)
+        {
+            Assert.Throws<InvalidCastException>(() => ShortValue.Create(value));
+        }
     }
 }

--- a/src/NoBox.Tests/SimpleValueOrTTests/SimpleValueOrTCreateTests.cs
+++ b/src/NoBox.Tests/SimpleValueOrTTests/SimpleValueOrTCreateTests.cs
@@ -172,5 +172,23 @@ namespace Pankraty.NoBox.Tests.SimpleValueOrTTests
             SimpleValueOrString s = value;
             Assert.Throws<InvalidOperationException>(() => { _ = s.Value; });
         }
+
+        [Test]
+        public void CanCreateSimpleValueFromGenericT()
+        {
+            var inputValue = 1;
+            var valueResult = Convert(inputValue);
+            Assert.IsTrue(valueResult.IsValue);
+
+            var inputReference = "Test";
+            var referenceResult = Convert(inputReference);
+            Assert.IsFalse(referenceResult.IsValue);
+            Assert.AreEqual("Test", referenceResult.Reference);
+
+            SimpleValueOr<object> Convert<T>(T value)
+            {
+                return SimpleValueOr<object>.Create(value);
+            }
+        }
     }
 }

--- a/src/NoBox.Tests/SimpleValueTests/SimpleValueCreateTests.cs
+++ b/src/NoBox.Tests/SimpleValueTests/SimpleValueCreateTests.cs
@@ -134,5 +134,14 @@ namespace Pankraty.NoBox.Tests.SimpleValueTests
             SimpleValue s = value;
             Assert.AreEqual(SimpleValueType.UShort, s.ValueType);
         }
+
+        [Test]
+        public void CannotCreateSimpleValue_FromStruct()
+        {
+            var value = new TestStruct();
+            Assert.Throws<InvalidCastException>(() => SimpleValue.Create(value));
+        }
+
+        private struct TestStruct { }
     }
 }

--- a/src/NoBox/Converters/IValueConverter.cs
+++ b/src/NoBox/Converters/IValueConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Pankraty.NoBox.Converters
 {
-    internal interface IValueConverter<in Tin, out T> where Tin: struct
+    internal interface IValueConverter<Tin, T>
     {
         T GetValue(Tin value);
     }

--- a/src/NoBox/Converters/ShortValueConverter.cs
+++ b/src/NoBox/Converters/ShortValueConverter.cs
@@ -17,7 +17,21 @@ namespace Pankraty.NoBox.Converters
         IValueConverter<ShortValue, char      >,
         IValueConverter<ShortValue, DateTime  >,
         IValueConverter<ShortValue, TimeSpan  >,
-        IValueConverter<ShortValue, ShortValue>
+        IValueConverter<ShortValue, ShortValue>,
+        IValueConverter<bool      , ShortValue>,
+        IValueConverter<sbyte     , ShortValue>,
+        IValueConverter<byte      , ShortValue>,
+        IValueConverter<short     , ShortValue>,
+        IValueConverter<ushort    , ShortValue>,
+        IValueConverter<int       , ShortValue>,
+        IValueConverter<uint      , ShortValue>,
+        IValueConverter<long      , ShortValue>,
+        IValueConverter<ulong     , ShortValue>,
+        IValueConverter<float     , ShortValue>,
+        IValueConverter<double    , ShortValue>,
+        IValueConverter<char      , ShortValue>,
+        IValueConverter<DateTime  , ShortValue>,
+        IValueConverter<TimeSpan  , ShortValue>
     {
         private static readonly Lazy<ShortValueConverter> _instance = new Lazy<ShortValueConverter>(
             () => new ShortValueConverter());
@@ -55,6 +69,34 @@ namespace Pankraty.NoBox.Converters
         TimeSpan IValueConverter<ShortValue, TimeSpan>.GetValue(ShortValue value) => value;
 
         ShortValue IValueConverter<ShortValue, ShortValue>.GetValue(ShortValue value) => value;
+
+        ShortValue IValueConverter<bool, ShortValue>.GetValue(bool value) => value;
+
+        ShortValue IValueConverter<sbyte, ShortValue>.GetValue(sbyte value) => value;
+
+        ShortValue IValueConverter<byte, ShortValue>.GetValue(byte value) => value;
+
+        ShortValue IValueConverter<short, ShortValue>.GetValue(short value) => value;
+
+        ShortValue IValueConverter<ushort, ShortValue>.GetValue(ushort value) => value;
+
+        ShortValue IValueConverter<int, ShortValue>.GetValue(int value) => value;
+
+        ShortValue IValueConverter<uint, ShortValue>.GetValue(uint value) => value;
+
+        ShortValue IValueConverter<long, ShortValue>.GetValue(long value) => value;
+
+        ShortValue IValueConverter<ulong, ShortValue>.GetValue(ulong value) => value;
+
+        ShortValue IValueConverter<float, ShortValue>.GetValue(float value) => value;
+
+        ShortValue IValueConverter<double, ShortValue>.GetValue(double value) => value;
+
+        ShortValue IValueConverter<char, ShortValue>.GetValue(char value) => value;
+
+        ShortValue IValueConverter<DateTime, ShortValue>.GetValue(DateTime value) => value;
+
+        ShortValue IValueConverter<TimeSpan, ShortValue>.GetValue(TimeSpan value) => value;
 
         #endregion IValueConverter Implementations
     }

--- a/src/NoBox/Converters/SimpleValueConverter.cs
+++ b/src/NoBox/Converters/SimpleValueConverter.cs
@@ -20,7 +20,25 @@ namespace Pankraty.NoBox.Converters
         IValueConverter<SimpleValue, TimeSpan      >,
         IValueConverter<SimpleValue, Guid          >,
         IValueConverter<SimpleValue, decimal       >,
-        IValueConverter<SimpleValue, SimpleValue   >
+        IValueConverter<SimpleValue, SimpleValue   >,
+        IValueConverter<bool          , SimpleValue>,
+        IValueConverter<sbyte         , SimpleValue>,
+        IValueConverter<byte          , SimpleValue>,
+        IValueConverter<short         , SimpleValue>,
+        IValueConverter<ushort        , SimpleValue>,
+        IValueConverter<int           , SimpleValue>,
+        IValueConverter<uint          , SimpleValue>,
+        IValueConverter<long          , SimpleValue>,
+        IValueConverter<ulong         , SimpleValue>,
+        IValueConverter<float         , SimpleValue>,
+        IValueConverter<double        , SimpleValue>,
+        IValueConverter<char          , SimpleValue>,
+        IValueConverter<DateTime      , SimpleValue>,
+        IValueConverter<DateTimeOffset, SimpleValue>,
+        IValueConverter<TimeSpan      , SimpleValue>,
+        IValueConverter<Guid          , SimpleValue>,
+        IValueConverter<decimal       , SimpleValue>
+
     {
         private static readonly Lazy<SimpleValueConverter> _instance = new Lazy<SimpleValueConverter>(
             () => new SimpleValueConverter());
@@ -65,6 +83,40 @@ namespace Pankraty.NoBox.Converters
 
         SimpleValue IValueConverter<SimpleValue, SimpleValue>.GetValue(SimpleValue value) => value;
 
+        SimpleValue IValueConverter<bool, SimpleValue>.GetValue(bool value) => value;
+
+        SimpleValue IValueConverter<sbyte, SimpleValue>.GetValue(sbyte value) => value;
+
+        SimpleValue IValueConverter<byte, SimpleValue>.GetValue(byte value) => value;
+
+        SimpleValue IValueConverter<short, SimpleValue>.GetValue(short value) => value;
+
+        SimpleValue IValueConverter<ushort, SimpleValue>.GetValue(ushort value) => value;
+
+        SimpleValue IValueConverter<int, SimpleValue>.GetValue(int value) => value;
+
+        SimpleValue IValueConverter<uint, SimpleValue>.GetValue(uint value) => value;
+
+        SimpleValue IValueConverter<long, SimpleValue>.GetValue(long value) => value;
+
+        SimpleValue IValueConverter<ulong, SimpleValue>.GetValue(ulong value) => value;
+
+        SimpleValue IValueConverter<float, SimpleValue>.GetValue(float value) => value;
+
+        SimpleValue IValueConverter<double, SimpleValue>.GetValue(double value) => value;
+
+        SimpleValue IValueConverter<char, SimpleValue>.GetValue(char value) => value;
+
+        SimpleValue IValueConverter<DateTime, SimpleValue>.GetValue(DateTime value) => value;
+
+        SimpleValue IValueConverter<DateTimeOffset, SimpleValue>.GetValue(DateTimeOffset value) => value;
+
+        SimpleValue IValueConverter<TimeSpan, SimpleValue>.GetValue(TimeSpan value) => value;
+
+        SimpleValue IValueConverter<Guid, SimpleValue>.GetValue(Guid value) => value;
+
+        SimpleValue IValueConverter<decimal, SimpleValue>.GetValue(decimal value) => value;
+ 
         #endregion IValueConverter Implementations
     }
 }

--- a/src/NoBox/NoBox.csproj
+++ b/src/NoBox/NoBox.csproj
@@ -11,7 +11,7 @@
     <LangVersion>8</LangVersion>
     <PackageProjectUrl>https://github.com/Pankraty/NoBox</PackageProjectUrl>
     <PackageTags>boxing value-types</PackageTags>
-    <PackageReleaseNotes>See https://github.com/Pankraty/NoBox/releases/tag/</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/Pankraty/NoBox/releases/%productVersion%/</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/NoBox/ShortValue.cs
+++ b/src/NoBox/ShortValue.cs
@@ -41,7 +41,7 @@ namespace Pankraty.NoBox
         /// <typeparam name="Tin">A primitive type</typeparam>
         /// <param name="value">A value to convert to <see cref="ShortValue"/></param>
         /// <returns>An instance of <see cref="ShortValue"/> holding the specified value.</returns>
-        public static ShortValue Create<Tin>(Tin value)
+        public static ShortValue Create<Tin>(Tin value) where Tin: struct
         {
             var converter = ShortValueConverter.Instance as IValueConverter<Tin, ShortValue>
                             ?? throw new InvalidCastException();

--- a/src/NoBox/ShortValue.cs
+++ b/src/NoBox/ShortValue.cs
@@ -33,6 +33,24 @@ namespace Pankraty.NoBox
 
         #endregion Data Fields
 
+        #region Static Members
+
+        /// <summary>
+        /// Create an instance of <see cref="ShortValue"/> from a generic argument/
+        /// </summary>
+        /// <typeparam name="Tin">A primitive type</typeparam>
+        /// <param name="value">A value to convert to <see cref="ShortValue"/></param>
+        /// <returns>An instance of <see cref="ShortValue"/> holding the specified value.</returns>
+        public static ShortValue Create<Tin>(Tin value)
+        {
+            var converter = ShortValueConverter.Instance as IValueConverter<Tin, ShortValue>
+                            ?? throw new InvalidCastException();
+            
+            return converter.GetValue(value);
+        }
+
+        #endregion Static Members
+
         #region Constructors
 
         public ShortValue(bool           value) : this() { _boolValue           = value; _valueType = SimpleValueType.Bool;           }

--- a/src/NoBox/ShortValueOrT.cs
+++ b/src/NoBox/ShortValueOrT.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Pankraty.NoBox.Converters;
+using System;
 using System.Collections.Generic;
 
 namespace Pankraty.NoBox
@@ -10,6 +11,28 @@ namespace Pankraty.NoBox
     public readonly struct ShortValueOr<T> : IEquatable<ShortValueOr<T>>
         where T : class
     {
+        #region Static Members
+
+        /// <summary>
+        /// Create an instance of <see cref="ShortValueOr{T}"/> from a generic argument avoiding its boxing
+        /// if possible.
+        /// </summary>
+        /// <typeparam name="Tin">A primitive or a reference type that can be casted to <typeparamref name="T"/></typeparam>
+        /// <param name="value">A value to convert to <see cref="ShortValueOr{T}"/></param>
+        /// <returns>An instance of <see cref="ShortValueOr{T}"/> holding the specified value.</returns>
+        public static ShortValueOr<T> Create<Tin>(Tin value)
+        {
+            if (ShortValueConverter.Instance is IValueConverter<Tin, ShortValue> converter)
+            {
+                return converter.GetValue(value);
+            }
+
+            // A fallback with boxing
+            return new ShortValueOr<T>((T)(object)value);
+        }
+
+        #endregion Static Members
+
         #region Public Properties
 
         /// <summary>

--- a/src/NoBox/SimpleValue.cs
+++ b/src/NoBox/SimpleValue.cs
@@ -44,7 +44,7 @@ namespace Pankraty.NoBox
         /// <typeparam name="Tin">A primitive type</typeparam>
         /// <param name="value">A value to convert to <see cref="SimpleValue"/></param>
         /// <returns>An instance of <see cref="SimpleValue"/> holding the specified value.</returns>
-        public static SimpleValue Create<Tin>(Tin value)
+        public static SimpleValue Create<Tin>(Tin value) where Tin : struct
         {
             var converter = SimpleValueConverter.Instance as IValueConverter<Tin, SimpleValue>
                             ?? throw new InvalidCastException();

--- a/src/NoBox/SimpleValue.cs
+++ b/src/NoBox/SimpleValue.cs
@@ -36,6 +36,24 @@ namespace Pankraty.NoBox
 
         #endregion Data Fields
 
+        #region Static Members
+
+        /// <summary>
+        /// Create an instance of <see cref="SimpleValue"/> from a generic argument/
+        /// </summary>
+        /// <typeparam name="Tin">A primitive type</typeparam>
+        /// <param name="value">A value to convert to <see cref="SimpleValue"/></param>
+        /// <returns>An instance of <see cref="SimpleValue"/> holding the specified value.</returns>
+        public static SimpleValue Create<Tin>(Tin value)
+        {
+            var converter = SimpleValueConverter.Instance as IValueConverter<Tin, SimpleValue>
+                            ?? throw new InvalidCastException();
+
+            return converter.GetValue(value);
+        }
+
+        #endregion Static Members
+
         #region Constructors
 
         public SimpleValue(bool           value) : this() { _boolValue           = value; _valueType = SimpleValueType.Bool;           }

--- a/src/NoBox/SimpleValueOrT.cs
+++ b/src/NoBox/SimpleValueOrT.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Pankraty.NoBox.Converters;
+using System;
 using System.Collections.Generic;
 
 namespace Pankraty.NoBox
@@ -10,6 +11,28 @@ namespace Pankraty.NoBox
     public readonly struct SimpleValueOr<T> : IEquatable<SimpleValueOr<T>>
         where T : class
     {
+        #region Static Members
+
+        /// <summary>
+        /// Create an instance of <see cref="SimpleValueOr{T}"/> from a generic argument avoiding its boxing
+        /// if possible.
+        /// </summary>
+        /// <typeparam name="Tin">A primitive or a reference type that can be casted to <typeparamref name="T"/></typeparam>
+        /// <param name="value">A value to convert to <see cref="SimpleValueOr{T}"/></param>
+        /// <returns>An instance of <see cref="SimpleValueOr{T}"/> holding the specified value.</returns>
+        public static SimpleValueOr<T> Create<Tin>(Tin value)
+        {
+            if (SimpleValueConverter.Instance is IValueConverter<Tin, SimpleValue> converter)
+            {
+                return converter.GetValue(value);
+            }
+
+            // A fallback with boxing
+            return new SimpleValueOr<T>((T)(object)value);
+        }
+
+        #endregion Static Members
+
         #region Public Properties
 
         /// <summary>


### PR DESCRIPTION
* Implement the static methods for creating `ShortValue`, `SimpleValue`, `ShortValueOr<T>`, `SimpleValueOr<T>` instances having a generic argument.
*  Remove co- and counter-variance from the interface as it hugely affected the performance in Net Framework
